### PR TITLE
fix: crash when stopRecording called

### DIFF
--- a/app/src/main/java/com/daiatech/karya/recorder/ui/screens/recorder/RecorderScreen.kt
+++ b/app/src/main/java/com/daiatech/karya/recorder/ui/screens/recorder/RecorderScreen.kt
@@ -231,7 +231,8 @@ private fun RecorderScreen(
                             }
                         },
                         contentPadding = PaddingValues(32.dp),
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        enabled = uiState.enableStop
                     ) {
                         when (uiState.state) {
                             UiState.State.INITIAL -> Text(text = "Start")

--- a/app/src/main/java/com/daiatech/karya/recorder/ui/screens/recorder/RecorderViewModel.kt
+++ b/app/src/main/java/com/daiatech/karya/recorder/ui/screens/recorder/RecorderViewModel.kt
@@ -58,6 +58,8 @@ class RecorderViewModel(
     }
 
     fun stopRecording() {
+        // disable stop button to concurrently
+        _uiState.update { it.copy(enableStop = false) }
         recorder.stopRecording()
     }
 

--- a/app/src/main/java/com/daiatech/karya/recorder/ui/screens/recorder/UiState.kt
+++ b/app/src/main/java/com/daiatech/karya/recorder/ui/screens/recorder/UiState.kt
@@ -4,7 +4,8 @@ data class UiState(
     val state: State,
     val recordingFileName: String?,
     val progress: Long,
-    val maxAmplitude: Int
+    val maxAmplitude: Int,
+    val enableStop: Boolean
 ) {
 
     enum class State {
@@ -15,7 +16,7 @@ data class UiState(
     val isPaused = state == State.PAUSED
 
     companion object {
-        val EMPTY = UiState(State.INITIAL, null, 0, 0)
+        val EMPTY = UiState(State.INITIAL, null, 0, 0, true)
     }
 }
 

--- a/rawaudiorecorder/src/main/java/com/daiatech/karya/rawaudiorecorder/RawAudioRecorder.kt
+++ b/rawaudiorecorder/src/main/java/com/daiatech/karya/rawaudiorecorder/RawAudioRecorder.kt
@@ -87,7 +87,7 @@ constructor(
         val outputFile = File(this.filePath)
         if(!outputFile.exists()) outputFile.createNewFile()
         listener.onPrepared()
-        Log.d("TAG", "Prepared RawAudioRecorder")
+        Log.d(TAG, "Prepared RawAudioRecorder")
 
         if (enablePreRecording) {
             preRecordJob?.cancel()
@@ -101,7 +101,7 @@ constructor(
             initializeAudioRecord()
 
             preRecordJob = coroutineScope.launch { writeAudioDataToPreRecordBuffer() }
-            Log.d("TAG", "Started Pre-Recording")
+            Log.d(TAG, "Started Pre-Recording")
         }
     }
 
@@ -122,14 +122,14 @@ constructor(
                 preRecordJob?.cancelAndJoin()
                 writeAudioDataToStorage()
             }
-            Log.d("TAG", "Started Recording")
+            Log.d(TAG, "Started Recording")
         }
     }
 
 
     @SuppressLint("MissingPermission")
     private fun initializeAudioRecord() {
-        Log.d("TAG", "Initialized AudioRecord")
+        Log.d(TAG, "Initialized AudioRecord")
         audioRecorder = AudioRecord(
             MediaRecorder.AudioSource.MIC,
             recorderConfig.sampleRate(),
@@ -164,7 +164,7 @@ constructor(
     }
 
     private suspend fun writeAudioDataToPreRecordBuffer() = withContext(Dispatchers.IO) {
-        Log.d("TAG", "Writing data to pre-record buffer")
+        Log.d(TAG, "Writing data to pre-record buffer")
         // Initialize pre-record buffer with a byte array of size [preRecordBufferSize] filling it with empty ByteArray
         preRecordBuffer.clear()
 
@@ -187,7 +187,7 @@ constructor(
         val file = File(filePath)
         val outputStream = file.outputStream()
 
-        Log.d("TAG", "Saving pre-record to disk")
+        Log.d(TAG, "Saving pre-record to disk")
         // add the pre-record buffer
         preRecordBuffer.forEach { bufferByte ->
             outputStream.write(bufferByte)
@@ -207,7 +207,7 @@ constructor(
             }
         }
 
-        Log.d("TAG", "Saving recording to disk")
+        Log.d(TAG, "Saving recording to disk")
         while (isRecording) {
             val operationStatus = audioRecorder.read(data, 0, bufferSizeInBytes)
 
@@ -221,7 +221,7 @@ constructor(
         recordedFileDurationMs =
             (file.length().toDouble() / (bytesPerSecond) * 1000).toLong()
 
-        Log.d("TAG", "Recording saved. Duration $recordedFileDurationMs")
+        Log.d(TAG, "Recording saved. Duration $recordedFileDurationMs")
         outputStream.close()
         publishResultJob.cancel()
         noiseSuppressor?.release()
@@ -270,5 +270,9 @@ constructor(
     fun resumeRecording() {
         isPaused = false
         listener.onResume()
+    }
+    
+    companion object {
+        const val TAG = "RawAudioRecorder"
     }
 }

--- a/rawaudiorecorder/src/main/java/com/daiatech/karya/rawaudiorecorder/RawAudioRecorder.kt
+++ b/rawaudiorecorder/src/main/java/com/daiatech/karya/rawaudiorecorder/RawAudioRecorder.kt
@@ -187,12 +187,11 @@ constructor(
         val file = File(filePath)
         val outputStream = file.outputStream()
 
-        Log.d(TAG, "Saving pre-record to disk")
-        // add the pre-record buffer
-        preRecordBuffer.forEach { bufferByte ->
-            outputStream.write(bufferByte)
+        if(preRecordBuffer.isNotEmpty()) {
+            Log.d(TAG, "Saving pre-record to disk")
+            preRecordBuffer.forEach { outputStream.write(it) }
+            preRecordBuffer.clear()
         }
-
 
         val publishResultJob = coroutineScope.launch(Dispatchers.Main) {
             while (isRecording) {
@@ -221,7 +220,7 @@ constructor(
         recordedFileDurationMs =
             (file.length().toDouble() / (bytesPerSecond) * 1000).toLong()
 
-        Log.d(TAG, "Recording saved. Duration $recordedFileDurationMs")
+        Log.d(TAG, "Recording stopped: audio duration $recordedFileDurationMs")
         outputStream.close()
         publishResultJob.cancel()
         noiseSuppressor?.release()


### PR DESCRIPTION
Fix race condition in RawAudioRecorder stop by tracking recordingJob
- Introduced `recordingJob` to track the active recording coroutine.
- Updated `startRecording()` to assign the launched coroutine to `recordingJob`.
- Updated progress publishing coroutine to use the existing `coroutineScope` with `Dispatchers.Main`.
- In `stopRecording()`, cancel and join `recordingJob` before calling `audioRecorder.stop()` and `release()`.
- Ensures the read loop finishes safely before stopping the AudioRecord, preventing IllegalStateException from native_stop()